### PR TITLE
Added mention of "agent-based modeling" to the masonclj entry.

### DIFF
--- a/content/en/docs/resources/libs.md
+++ b/content/en/docs/resources/libs.md
@@ -148,7 +148,7 @@ In addition to a few of the tools mentioned above, here is a list of dedicated t
 - [anglican](http://probprog.ml/anglican/index.html): `prob`,`rand`,`cljs` - a probabilistic programming language written in clojure, that supports a subset of clojure
 
 ## Random sampling and simulations
-- [masonclj](https://github.com/mars0i/masonclj) :star: (`act`): `rand` - a Clojure wrapper of [MASON](https://cs.gmu.edu/~eclab/projects/mason/), which is a Java library for discrete-event multiagent simulation.
+- [masonclj](https://github.com/mars0i/masonclj) :star: (`act`): `rand` - a Clojure wrapper of [MASON](https://cs.gmu.edu/~eclab/projects/mason/), which is a Java library for discrete-event multiagent simulation and agent-based modeling.
 - [dsim.cljc](https://github.com/dvlopt/dsim.cljc) :star: (`act`): `rand`,`cljs` - an event-driven engine for Clojure(script) heavily borrowing ideas from discrete-event simulation and hybrid dynamical systems
 - [date-gen](https://github.com/conjunctive/date-gen) (`act`): `rand` - randomized date generation supporting CSV output
 - [drand](https://github.com/jimpil/drand-clj): `rand` - a client to the [Drand](https://drand.love) randomness servifdce


### PR DESCRIPTION
Agent-based modeling and discrete-event simulation are overlapping
modeling traditions.  I would guess that anything you can do with a
library based in one tradition can be done with a library based in the
other tradition, but of course different libraries may emphasize
methods that are emphasized in a given tradition.  Some people are
familiar with one term or the other, so it's useful to mention both.  (I
wasn't always familiar with the term "discrete event simulation", even
though I was using MASON and its web page says it's a "discrete-event
multiagent simulation library"! :-)