### PR TITLE
Format news titles for better readability

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -2,9 +2,9 @@
 title : "Scicloj"
 description: "Helping Clojure grow in new fields"
 lead: "Helping Clojure grow in new fields"
-news1title: "🧪Join our dev groups and study groups🧪"
+news1title: "🧪 Join our dev groups and study groups 🧪"
 news1link: "/docs/community/groups/"
-news2title: "📅Follow our events at the Clojure Events Calendar feed📅"
+news2title: "📅 Follow our events at the Clojure Events Calendar feed 📅"
 news2link: "https://scicloj.github.io/docs/community/events/"
 ddate: 2020-10-06T08:47:36+00:00
 lastmod: 2025-05-17


### PR DESCRIPTION
Added spaces around emojis in news titles for consistency.
Before
<img width="818" height="398" alt="image" src="https://github.com/user-attachments/assets/667e309d-efdf-42c4-a61b-f1ab24d40255" />
After
<img width="818" height="398" alt="image" src="https://github.com/user-attachments/assets/0d102d89-4aea-4d81-a4c2-fda0f6b9b0e4" />
